### PR TITLE
Improve ip addresses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:22.04
 
-RUN apt update && apt install -y ruby iputils-ping net-tools nmap
+RUN apt update && apt install -y ruby iputils-ping net-tools nmap curl

--- a/check_connectivity.sh
+++ b/check_connectivity.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-for name in client1 server1 server2 client2; do 
+for name in client1 server1 server2 client2 client3; do
     docker exec -it $name /shared/common/check_connectivity.rb
 done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     networks:
       net1:
         ipv4_address: 192.168.57.11
+      net4:
+        ipv4_address: 192.168.60.11
     volumes:
         - ./shared/common:/shared/common
         - ./shared/client1_data:/shared/unique
@@ -21,9 +23,9 @@ services:
     tty: true
     networks:
       net1:
-        ipv4_address: 192.168.57.22
+        ipv4_address: 192.168.57.21
       net2:
-        ipv4_address: 192.168.58.33
+        ipv4_address: 192.168.58.21
     volumes:
         - ./shared/common:/shared/common
         - ./shared/server1_data:/shared/unique
@@ -36,9 +38,9 @@ services:
     tty: true
     networks:
       net2:
-        ipv4_address: 192.168.58.44
+        ipv4_address: 192.168.58.22
       net3:
-        ipv4_address: 192.168.59.55
+        ipv4_address: 192.168.59.22
     volumes:
         - ./shared/common:/shared/common
         - ./shared/server2_data:/shared/unique
@@ -51,7 +53,22 @@ services:
     tty: true
     networks:
       net3:
-        ipv4_address: 192.168.59.66
+        ipv4_address: 192.168.59.12
+      net4:
+        ipv4_address: 192.168.60.12
+    volumes:
+        - ./shared/common:/shared/common
+        - ./shared/client2_data:/shared/unique
+
+  client3:
+    container_name: client3
+    hostname: client3
+    build:
+      context: .
+    tty: true
+    networks:
+      net4:
+        ipv4_address: 192.168.60.13
     volumes:
         - ./shared/common:/shared/common
         - ./shared/client2_data:/shared/unique
@@ -74,3 +91,9 @@ networks:
     ipam:
       config:
         - subnet: 192.168.59.0/24
+
+  net4:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.60.0/24

--- a/shared/common/check_connectivity.rb
+++ b/shared/common/check_connectivity.rb
@@ -10,14 +10,15 @@ hostname=Socket.gethostname
 p="192.168."
 
 machines = [
-  ["client1", "#{p}57.11"],
-  ["server1", "#{p}57.22", "#{p}58.33"],
-  ["server2", "#{p}58.44", "#{p}59.55"],
-  ["client2", "#{p}59.66"],
+  ["client1", "#{p}57.11", "#{p}60.11"],
+  ["server1", "#{p}57.21", "#{p}58.21"],
+  ["server2", "#{p}58.22", "#{p}59.22"],
+  ["client2", "#{p}59.12", "#{p}60.12"],
+  ["client3", "#{p}60.13"],
 ]
 
-def reachable?(ip) 
-  system 'ping', '-c', '1', ip, [:out, :err] => '/dev/null'
+def reachable?(ip)
+  system 'ping', '-c', '1', '-W', '1', ip, [:out, :err] => '/dev/null'
 end
 
 machines.each do |l|


### PR DESCRIPTION
Change ip addresses of the containers so that third octet can be used to distingish network and fourth to distingish client. So every container has the same fourth octet on all interfaces:
11 - client1
12 - client2
13 - client3
21 - server1
22 - server2